### PR TITLE
Create CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,8 @@
+/LICENSE @mattborja
+/README.md @mattboraj
+/schema.json @mattborja
+/.github @mattborja
+/registry @mattborja
+/registry/*.json
+/registry/99BB608E30380C451952D6BBA1C7E813F160A407.json @mattborja
+/registry/F30FF4FC936584574EE3251833688C2EDC08CD38.json @mattborja


### PR DESCRIPTION
Enforce CODEOWNERS on framework-level objects.

Note: The rules included for /registry are intended to restrict unauthorized changes to the /registry directory and the repository owner's key files within, while leaving all others (*.json) unassigned to allow for external contrbutions.