### PR TITLE
Add signed artifact demonstrating private key use

### DIFF
--- a/registry/99BB608E30380C451952D6BBA1C7E813F160A407.json
+++ b/registry/99BB608E30380C451952D6BBA1C7E813F160A407.json
@@ -4,8 +4,9 @@
   "validity": "full",
   "refs": [
     {
-      "date": "2024-10-06",
-      "comment": "Private key holder",
+      "date": "2024-11-27",
+      "comment": "Signed artifact demonstrating private key use: `echo -n '3ED3 3CCE 4BED 165C 9107 3D9F 65B8 8DAC 23AF 5BCD E520 F723 C1E6 2A69 B369 F278' | gpg --clearsign --local-user D41A83E1C6B701619D0D812FC3F69D1BE6BCBD16`",
+      "artifact": "-----BEGIN PGP SIGNED MESSAGE-----\nHash: SHA512\n\n3ED3 3CCE 4BED 165C 9107 3D9F 65B8 8DAC 23AF 5BCD E520 F723 C1E6 2A69 B369 F278\n-----BEGIN PGP SIGNATURE-----\n\niHUEARYKAB0WIQTUGoPhxrcBYZ0NgS/D9p0b5ry9FgUCZ0dD0AAKCRDD9p0b5ry9\nFvonAQCHwAHRduopWn8I534GNRXQ0+dX5JO2ztnFxnlwZd+NMAD/Wr0NWLEc+eCf\nQm2UHkDp8lKswj6kXxTi9GI3elvpQgE=\n=L95q\n-----END PGP SIGNATURE-----\n",
       "type": "key"
     },
     {

--- a/registry/F30FF4FC936584574EE3251833688C2EDC08CD38.json
+++ b/registry/F30FF4FC936584574EE3251833688C2EDC08CD38.json
@@ -5,6 +5,7 @@
   "refs": [
     {
       "date": "2023-07-18",
+      "comment": "Signed artifact demonstrating private key use: `echo -n '3ED3 3CCE 4BED 165C 9107 3D9F 65B8 8DAC 23AF 5BCD E520 F723 C1E6 2A69 B369 F278' | gpg --clearsign`"
       "artifact": "-----BEGIN PGP SIGNED MESSAGE-----\nHash: SHA512\n\n3ED3 3CCE 4BED 165C 9107 3D9F 65B8 8DAC 23AF 5BCD E520 F723 C1E6 2A69 B369 F278\n-----BEGIN PGP SIGNATURE-----\n\niQIzBAEBCgAdFiEESCXoP0Z0qi7+jBnOpjIppLTMI9kFAmdHP+gACgkQpjIppLTM\nI9km0xAAg0IYSosZyMX2Sel94R2kxr0bgILYcw0C1SCHmBCpXig0Iw0arWcyp97r\ns/elq17kyuRuHA8r+m3byAYvaz+7rj7SeCAVrSWqS+7MT/9m3ZTIq0NlLysXEExY\nF50LH5w6CmJdhtqEx/6ZJC13QA05O8PAY7engipiSMag/927NR5wXVLmDnPmn4GB\nUV58ZFsIvukK4VuVsASyk6NyhlYy3GUDTsIhGDGe7/fvrRbCgUI5lEw2/5n+RomI\nmWMqM58pI+6ETATYB8zh7RllVCH6Iawc0AiyNXZ3oewM8++T8kOJ/LLhyNSRbbVy\n8sFtha0ac9wsL0FOonD+skfIo2SfpD9c5EK6BttuQuZRktfPntP/Ky6jeVH8riWL\ni+0Ksz1PhnEL9ePMtJA9KzAVA3YU7PxD5KojV01rnLxqPH4ALUBghHhNbKYzAi1m\nxMVGx47jcz989AZmBCzQcQgFtH717CXldDxRfkdxTWZktm65fRV0m1RAgNhIXsrW\nYZXwjq7SP0R6COKfyKJfZ4cHuIBui86DYenly+QxLcuqns13QvixbjiGT/6uqd6w\nOlAsEI1rVrtlDTHVXo43uowLT+2oBYz1xFNrnNfuyruvwhkxfxwClauuIxz32gDK\nxJKrv2aQPNrApH9F+PhppwjUdj0Ndk3Y+vtrOLrk9/4S3haRtRU=\n=GpMP\n-----END PGP SIGNATURE-----\n",
       "type": "key"
     }

--- a/registry/F30FF4FC936584574EE3251833688C2EDC08CD38.json
+++ b/registry/F30FF4FC936584574EE3251833688C2EDC08CD38.json
@@ -4,7 +4,7 @@
   "validity": "full",
   "refs": [
     {
-      "date": "2023-07-18",
+      "date": "2024-11-27",
       "comment": "Signed artifact demonstrating private key use: `echo -n '3ED3 3CCE 4BED 165C 9107 3D9F 65B8 8DAC 23AF 5BCD E520 F723 C1E6 2A69 B369 F278' | gpg --clearsign`",
       "artifact": "-----BEGIN PGP SIGNED MESSAGE-----\nHash: SHA512\n\n3ED3 3CCE 4BED 165C 9107 3D9F 65B8 8DAC 23AF 5BCD E520 F723 C1E6 2A69 B369 F278\n-----BEGIN PGP SIGNATURE-----\n\niQIzBAEBCgAdFiEESCXoP0Z0qi7+jBnOpjIppLTMI9kFAmdHP+gACgkQpjIppLTM\nI9km0xAAg0IYSosZyMX2Sel94R2kxr0bgILYcw0C1SCHmBCpXig0Iw0arWcyp97r\ns/elq17kyuRuHA8r+m3byAYvaz+7rj7SeCAVrSWqS+7MT/9m3ZTIq0NlLysXEExY\nF50LH5w6CmJdhtqEx/6ZJC13QA05O8PAY7engipiSMag/927NR5wXVLmDnPmn4GB\nUV58ZFsIvukK4VuVsASyk6NyhlYy3GUDTsIhGDGe7/fvrRbCgUI5lEw2/5n+RomI\nmWMqM58pI+6ETATYB8zh7RllVCH6Iawc0AiyNXZ3oewM8++T8kOJ/LLhyNSRbbVy\n8sFtha0ac9wsL0FOonD+skfIo2SfpD9c5EK6BttuQuZRktfPntP/Ky6jeVH8riWL\ni+0Ksz1PhnEL9ePMtJA9KzAVA3YU7PxD5KojV01rnLxqPH4ALUBghHhNbKYzAi1m\nxMVGx47jcz989AZmBCzQcQgFtH717CXldDxRfkdxTWZktm65fRV0m1RAgNhIXsrW\nYZXwjq7SP0R6COKfyKJfZ4cHuIBui86DYenly+QxLcuqns13QvixbjiGT/6uqd6w\nOlAsEI1rVrtlDTHVXo43uowLT+2oBYz1xFNrnNfuyruvwhkxfxwClauuIxz32gDK\nxJKrv2aQPNrApH9F+PhppwjUdj0Ndk3Y+vtrOLrk9/4S3haRtRU=\n=GpMP\n-----END PGP SIGNATURE-----\n",
       "type": "key"

--- a/registry/F30FF4FC936584574EE3251833688C2EDC08CD38.json
+++ b/registry/F30FF4FC936584574EE3251833688C2EDC08CD38.json
@@ -5,7 +5,7 @@
   "refs": [
     {
       "date": "2023-07-18",
-      "comment": "Signed artifact demonstrating private key use: `echo -n '3ED3 3CCE 4BED 165C 9107 3D9F 65B8 8DAC 23AF 5BCD E520 F723 C1E6 2A69 B369 F278' | gpg --clearsign`"
+      "comment": "Signed artifact demonstrating private key use: `echo -n '3ED3 3CCE 4BED 165C 9107 3D9F 65B8 8DAC 23AF 5BCD E520 F723 C1E6 2A69 B369 F278' | gpg --clearsign`",
       "artifact": "-----BEGIN PGP SIGNED MESSAGE-----\nHash: SHA512\n\n3ED3 3CCE 4BED 165C 9107 3D9F 65B8 8DAC 23AF 5BCD E520 F723 C1E6 2A69 B369 F278\n-----BEGIN PGP SIGNATURE-----\n\niQIzBAEBCgAdFiEESCXoP0Z0qi7+jBnOpjIppLTMI9kFAmdHP+gACgkQpjIppLTM\nI9km0xAAg0IYSosZyMX2Sel94R2kxr0bgILYcw0C1SCHmBCpXig0Iw0arWcyp97r\ns/elq17kyuRuHA8r+m3byAYvaz+7rj7SeCAVrSWqS+7MT/9m3ZTIq0NlLysXEExY\nF50LH5w6CmJdhtqEx/6ZJC13QA05O8PAY7engipiSMag/927NR5wXVLmDnPmn4GB\nUV58ZFsIvukK4VuVsASyk6NyhlYy3GUDTsIhGDGe7/fvrRbCgUI5lEw2/5n+RomI\nmWMqM58pI+6ETATYB8zh7RllVCH6Iawc0AiyNXZ3oewM8++T8kOJ/LLhyNSRbbVy\n8sFtha0ac9wsL0FOonD+skfIo2SfpD9c5EK6BttuQuZRktfPntP/Ky6jeVH8riWL\ni+0Ksz1PhnEL9ePMtJA9KzAVA3YU7PxD5KojV01rnLxqPH4ALUBghHhNbKYzAi1m\nxMVGx47jcz989AZmBCzQcQgFtH717CXldDxRfkdxTWZktm65fRV0m1RAgNhIXsrW\nYZXwjq7SP0R6COKfyKJfZ4cHuIBui86DYenly+QxLcuqns13QvixbjiGT/6uqd6w\nOlAsEI1rVrtlDTHVXo43uowLT+2oBYz1xFNrnNfuyruvwhkxfxwClauuIxz32gDK\nxJKrv2aQPNrApH9F+PhppwjUdj0Ndk3Y+vtrOLrk9/4S3haRtRU=\n=GpMP\n-----END PGP SIGNATURE-----\n",
       "type": "key"
     }

--- a/registry/F30FF4FC936584574EE3251833688C2EDC08CD38.json
+++ b/registry/F30FF4FC936584574EE3251833688C2EDC08CD38.json
@@ -5,7 +5,7 @@
   "refs": [
     {
       "date": "2023-07-18",
-      "comment": "Private key holder",
+      "artifact": "-----BEGIN PGP SIGNED MESSAGE-----\nHash: SHA512\n\n3ED3 3CCE 4BED 165C 9107 3D9F 65B8 8DAC 23AF 5BCD E520 F723 C1E6 2A69 B369 F278\n-----BEGIN PGP SIGNATURE-----\n\niQIzBAEBCgAdFiEESCXoP0Z0qi7+jBnOpjIppLTMI9kFAmdHP+gACgkQpjIppLTM\nI9km0xAAg0IYSosZyMX2Sel94R2kxr0bgILYcw0C1SCHmBCpXig0Iw0arWcyp97r\ns/elq17kyuRuHA8r+m3byAYvaz+7rj7SeCAVrSWqS+7MT/9m3ZTIq0NlLysXEExY\nF50LH5w6CmJdhtqEx/6ZJC13QA05O8PAY7engipiSMag/927NR5wXVLmDnPmn4GB\nUV58ZFsIvukK4VuVsASyk6NyhlYy3GUDTsIhGDGe7/fvrRbCgUI5lEw2/5n+RomI\nmWMqM58pI+6ETATYB8zh7RllVCH6Iawc0AiyNXZ3oewM8++T8kOJ/LLhyNSRbbVy\n8sFtha0ac9wsL0FOonD+skfIo2SfpD9c5EK6BttuQuZRktfPntP/Ky6jeVH8riWL\ni+0Ksz1PhnEL9ePMtJA9KzAVA3YU7PxD5KojV01rnLxqPH4ALUBghHhNbKYzAi1m\nxMVGx47jcz989AZmBCzQcQgFtH717CXldDxRfkdxTWZktm65fRV0m1RAgNhIXsrW\nYZXwjq7SP0R6COKfyKJfZ4cHuIBui86DYenly+QxLcuqns13QvixbjiGT/6uqd6w\nOlAsEI1rVrtlDTHVXo43uowLT+2oBYz1xFNrnNfuyruvwhkxfxwClauuIxz32gDK\nxJKrv2aQPNrApH9F+PhppwjUdj0Ndk3Y+vtrOLrk9/4S3haRtRU=\n=GpMP\n-----END PGP SIGNATURE-----\n",
       "type": "key"
     }
   ],


### PR DESCRIPTION
Note: When verifying, signed message should be piped to `gpg --with-fingerprint` to show subkey's corresponding primary key (3368 8C2E DC08 CD38)