### PR TITLE
Amend Compliance (Minimum No. References)

### DIFF
--- a/COMPLIANCE.md
+++ b/COMPLIANCE.md
@@ -26,7 +26,7 @@ JSON schema validation ([schema.json](/schema.json)) applied as follows:
 - Requires minimum GPG identity fingerprint length of 128 bits (16 characters)
 - Requires label or name of associated identity
 - Requires validity level to be either `full`, `marginal`, `revoked`, or `none`.
-- Requires a list of references (refs) that provide evidence to support the identity assertion, specifying required fields: date, comment, type (`role`, `user`, or `key`)
+- Requires a **minimum of 2 references** (`refs`) that provide evidence to support the identity assertion, specifying required fields: date, comment, type (`role`, `user`, or `key`)
 - Requires a list of tags associated with the identity, for the purpose of categorizing or further classifying the associated identity
 - No additional properties are permitted
 - Limit **1 identity per file** with strict filename validation ([filename-validate.sh](/filename-validate.sh))

--- a/registry/4AF4D83EEDDF43DA3C06CB3101483F262A4B3FF0.json
+++ b/registry/4AF4D83EEDDF43DA3C06CB3101483F262A4B3FF0.json
@@ -8,6 +8,12 @@
         "comment": "Self-verified with full name verification during 2022-04-01 dev call.",
         "url": "https://shibboleth.atlassian.net/wiki/spaces/DEV/pages/2951020545/2022-04-01",
         "type": "user"
+      },
+      {
+        "date": "2022-04-01",
+        "comment": "Listed as project lead with other named collaborators in Shibboleth projects: Scott Cantor, Philip Smart, Steven Premeau, Tom Zeller, John W. O'Brien, Daniel Fisher, Henri Mikkonen.",
+        "url": "https://shibboleth.atlassian.net/jira/projects",
+        "type": "role"
       }
     ],
     "tags": [

--- a/registry/6D18FD63708FCCA079B68CCE026691839355EBCA.json
+++ b/registry/6D18FD63708FCCA079B68CCE026691839355EBCA.json
@@ -8,6 +8,12 @@
         "comment": "Self-verified during 2022-04-01 dev call.",
         "url": "https://shibboleth.atlassian.net/wiki/spaces/DEV/pages/2951020545/2022-04-01",
         "type": "user"
+      },
+      {
+        "date": "2022-04-01",
+        "comment": "Listed as project lead with other named collaborators in Shibboleth projects: Scott Cantor, Philip Smart, Rod Widdowson, Steven Premeau, Tom Zeller, John W. O'Brien, Daniel Fisher.",
+        "url": "https://shibboleth.atlassian.net/jira/projects",
+        "type": "role"
       }
     ],
     "tags": [

--- a/registry/B5B5DD332142AD657E8D87AC7D27E610B8A3DC52.json
+++ b/registry/B5B5DD332142AD657E8D87AC7D27E610B8A3DC52.json
@@ -8,6 +8,12 @@
         "comment": "Self-verified during 2022-04-01 dev call.",
         "url": "https://shibboleth.atlassian.net/wiki/spaces/DEV/pages/2951020545/2022-04-01",
         "type": "user"
+      },
+      {
+        "date": "2022-04-01",
+        "comment": "Listed as project lead with other named collaborators in Shibboleth projects: Scott Cantor, Rod Widdowson, Steven Premeau, Tom Zeller, John W. O'Brien, Daniel Fisher, Henri Mikkonen.",
+        "url": "https://shibboleth.atlassian.net/jira/projects",
+        "type": "role"
       }
     ],
     "tags": [

--- a/registry/F30FF4FC936584574EE3251833688C2EDC08CD38.json
+++ b/registry/F30FF4FC936584574EE3251833688C2EDC08CD38.json
@@ -8,6 +8,11 @@
       "comment": "Signed artifact demonstrating private key use: `echo -n '3ED3 3CCE 4BED 165C 9107 3D9F 65B8 8DAC 23AF 5BCD E520 F723 C1E6 2A69 B369 F278' | gpg --clearsign`",
       "artifact": "-----BEGIN PGP SIGNED MESSAGE-----\nHash: SHA512\n\n3ED3 3CCE 4BED 165C 9107 3D9F 65B8 8DAC 23AF 5BCD E520 F723 C1E6 2A69 B369 F278\n-----BEGIN PGP SIGNATURE-----\n\niQIzBAEBCgAdFiEESCXoP0Z0qi7+jBnOpjIppLTMI9kFAmdHP+gACgkQpjIppLTM\nI9km0xAAg0IYSosZyMX2Sel94R2kxr0bgILYcw0C1SCHmBCpXig0Iw0arWcyp97r\ns/elq17kyuRuHA8r+m3byAYvaz+7rj7SeCAVrSWqS+7MT/9m3ZTIq0NlLysXEExY\nF50LH5w6CmJdhtqEx/6ZJC13QA05O8PAY7engipiSMag/927NR5wXVLmDnPmn4GB\nUV58ZFsIvukK4VuVsASyk6NyhlYy3GUDTsIhGDGe7/fvrRbCgUI5lEw2/5n+RomI\nmWMqM58pI+6ETATYB8zh7RllVCH6Iawc0AiyNXZ3oewM8++T8kOJ/LLhyNSRbbVy\n8sFtha0ac9wsL0FOonD+skfIo2SfpD9c5EK6BttuQuZRktfPntP/Ky6jeVH8riWL\ni+0Ksz1PhnEL9ePMtJA9KzAVA3YU7PxD5KojV01rnLxqPH4ALUBghHhNbKYzAi1m\nxMVGx47jcz989AZmBCzQcQgFtH717CXldDxRfkdxTWZktm65fRV0m1RAgNhIXsrW\nYZXwjq7SP0R6COKfyKJfZ4cHuIBui86DYenly+QxLcuqns13QvixbjiGT/6uqd6w\nOlAsEI1rVrtlDTHVXo43uowLT+2oBYz1xFNrnNfuyruvwhkxfxwClauuIxz32gDK\nxJKrv2aQPNrApH9F+PhppwjUdj0Ndk3Y+vtrOLrk9/4S3haRtRU=\n=GpMP\n-----END PGP SIGNATURE-----\n",
       "type": "key"
+    },
+    {
+      "date": "2024-12-02",
+      "comment": "Manual review and approval of self-attestation",
+      "type": "user"
     }
   ],
   "tags": [

--- a/schema.json
+++ b/schema.json
@@ -24,6 +24,7 @@
     },
     "refs": {
       "type": "array",
+      "minItems": 2,
       "items": {
         "type": "object",
         "properties": {


### PR DESCRIPTION
Schema now requires a **minimum of 2 references** per identity assertion.