### PR TITLE
OP: Inference Papers and Identity Proof Criterion

### DIFF
--- a/INFERENCE.md
+++ b/INFERENCE.md
@@ -10,4 +10,4 @@ Licensed under the MIT License.
 ```
 
 - [Open Proof of Cryptographic Key Ownership Using Git as a Registry](/papers/open-proof-key-ownership-git-registry-mattborja-2025.md) - A decentralized approach for cryptographic proof of key ownership using clearsigned artifacts and Git as a global registry
-- [Self-Attestation of Additional GPG Keys Using GitHub’s Internal Signing Key](/papers/self-attestation-gpg-keys-github-mattborja-2025.md)
+- [Self-Attestation of Additional GPG Keys Using GitHub’s Internal Signing Key](/papers/self-attestation-gpg-keys-github-mattborja-2025.md) - A method for asserting ownership of an external GPG key in a GitHub repository with Vigilant Mode enabled

--- a/INFERENCE.md
+++ b/INFERENCE.md
@@ -1,4 +1,13 @@
-# Inferences
-> In legal contexts, an inference is a logical conclusion that a factfinder (such as a judge or jury) can reasonably draw from the evidence presented, even if the conclusion is not explicitly proven by direct evidence. Inferences must be based on rational reasoning and the presented circumstantial evidence.
+# Inference Papers
+In legal contexts, an **inference** is a logical conclusion that a factfinder (such as a judge or jury) can reasonably draw from the evidence presented, even if the conclusion is not explicitly proven by direct evidence. Inferences must be based on rational reasoning and the presented circumstantial evidence.
+
+## Papers
+Unless otherwise denoted, all papers in this repository are assigned copyright as follows:
+
+```
+Copyright © 2025 Matt Borja  
+Licensed under the MIT License.
+```
 
 - [Open Proof of Cryptographic Key Ownership Using Git as a Registry](/papers/open-proof-key-ownership-git-registry-mattborja-2025.md) - A decentralized approach for cryptographic proof of key ownership using clearsigned artifacts and Git as a global registry
+- [Self-Attestation of Additional GPG Keys Using GitHub’s Internal Signing Key](/papers/self-attestation-gpg-keys-github-mattborja-2025.md)

--- a/INFERENCE.md
+++ b/INFERENCE.md
@@ -1,11 +1,4 @@
 # Inferences
 > In legal contexts, an inference is a logical conclusion that a factfinder (such as a judge or jury) can reasonably draw from the evidence presented, even if the conclusion is not explicitly proven by direct evidence. Inferences must be based on rational reasoning and the presented circumstantial evidence.
 
-## Keyholder
-- Artifact is timestamped
-- Artifact signature is presented
-- Artifact signsture bears public key fingerprint
-- Public key fingerprint corresponds to private key component
-- Private key component is held securely by owner
-
-**Inference:** User is able to demonstrate current ownership of private key.
+- [Open Proof of Cryptographic Key Ownership Using Git as a Registry](/papers/open-proof-key-ownership-git-registry-mattborja-2025.md) - A decentralized approach for cryptographic proof of key ownership using clearsigned artifacts and Git as a global registry

--- a/INFERENCE.md
+++ b/INFERENCE.md
@@ -1,0 +1,11 @@
+# Inferences
+> In legal contexts, an inference is a logical conclusion that a factfinder (such as a judge or jury) can reasonably draw from the evidence presented, even if the conclusion is not explicitly proven by direct evidence. Inferences must be based on rational reasoning and the presented circumstantial evidence.
+
+## Keyholder
+- Artifact is timestamped
+- Artifact signature is presented
+- Artifact signsture bears public key fingerprint
+- Public key fingerprint corresponds to private key component
+- Private key component is held securely by owner
+
+**Inference:** User is able to demonstrate current ownership of private key.

--- a/PROOFS.md
+++ b/PROOFS.md
@@ -1,0 +1,9 @@
+# Proofs
+Circumstantial evidence corrobortaing the presumptive correlation between identity proofs and their reasonable outcomes.
+
+| Proof (controlled by subject)                | Presumption (implicated of subject)                           | Assertion (not controlled by subject)                            |
+|----------------------------------------------|---------------------------------------------------------------|------------------------------------------------------------------|
+| GPG signature bearing public key fingerprint | Corresponding key exists and is within possession of subject  | Public key cryptography asserts the relationship of GPG keypairs |
+| Licenses, fingerprints, certifications       | Subject has been externally authenticated by a trusted entity | Issuing agency bears official record of license identifier       |
+| Project involvement, published content       | Subject is observable with role affiliations                  | System timestamps                                                |
+| S/MIME encrypted and/or signed email | Email address, inbox, and corresponding key is within possession of subject | Public key cryptography asserts the relationship of RSA/ECC keypairs used in association with the given email |

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Each identity assertion is an object containing the following fields:
     }
   ]
   ```
-
+  For a complete list of known identity references, please see [**REFS.md**](/REFS.md).
 - **`tags`**:  
   An array of strings representing keywords or categories that provide additional context for the keyholder’s identity. Tags might include roles (e.g., `developer`, `maintainer`) or organizations (e.g., `OWASP`).  
   Example:  

--- a/REFS.md
+++ b/REFS.md
@@ -1,4 +1,4 @@
-# Proofs
+# ID References (Proofs)
 Circumstantial evidence corrobortaing the presumptive correlation between identity proofs and their reasonable outcomes.
 
 | Proof (controlled by subject)                | Presumption (implicated of subject)                           | Assertion (not controlled by subject)                            |

--- a/artifact-sign.sh
+++ b/artifact-sign.sh
@@ -1,11 +1,64 @@
-#!/bin/sh
-# For demonstrating use of signing key, private key holder must sign the approved artifact shown below to include in their submission.
-ARTIFACT="3ED3 3CCE 4BED 165C 9107 3D9F 65B8 8DAC 23AF 5BCD E520 F723 C1E6 2A69 B369 F278"
+#!/bin/bash
+# MIT License
+# 
+# Copyright (c) 2025 @mattborja
+# 
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+# 
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+# 
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
 
-KEY="$1"
-if [ -z "$KEY" ]; then
-  echo "Usage: $0 <signing key ID>"
-  exit 1
+# For demonstrating use of signing key, private key holder must sign the approved artifact constructed below to include in their submission.
+#
+# The artifact format is: urn:artifact:<scope>:<random_sequence>
+# - <scope>: A static identifier (e.g., "mattborja/identity")
+# - <random_sequence>: A 32-byte cryptographically strong random sequence
+#
+# Optional: Specify a signing key with `--local-user <key_id>`.
+
+#
+# DO NOT modify this script below this line.
+#
+
+SCOPE="mattborja/identity"
+LOCAL_USER=""
+
+# Parse optional arguments
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --local-user)
+      LOCAL_USER="$2"
+      shift 2
+      ;;
+    *)
+      echo "Usage: $0 [--local-user <key_id>]"
+      exit 1
+      ;;
+  esac
+done
+
+# Generate a 32-byte cryptographically strong random sequence
+RANDOM_SEQUENCE=$(openssl rand -hex 32)
+
+# Construct the artifact
+ARTIFACT="urn:artifact:${SCOPE}:${RANDOM_SEQUENCE}"
+
+# Sign and output
+if [ -n "$LOCAL_USER" ]; then
+  echo "$ARTIFACT" | gpg --clearsign --local-user "$LOCAL_USER"
+else
+  echo "$ARTIFACT" | gpg --clearsign
 fi
-
-echo "$ARTIFACT" | gpg --clearsign --local-user "$KEY"

--- a/papers/open-proof-key-ownership-git-registry-mattborja-2025.md
+++ b/papers/open-proof-key-ownership-git-registry-mattborja-2025.md
@@ -1,0 +1,148 @@
+**Title:**
+Open Proof of Cryptographic Key Ownership Using Git as a Registry
+
+**Author:**
+Matt Borja
+
+**Copyright:**
+Copyright © 2025 Matt Borja  
+Licensed under the MIT License.
+
+---
+
+**Abstract**
+This paper presents a decentralized approach for cryptographic proof of key ownership using clearsigned artifacts and Git as a global registry. By combining the immutability and transparency of Git with GPG’s clearsigning capabilities, the proposed method ensures global replay resistance, complete traceability, and secure validation. A detailed workflow is outlined, leveraging Git’s content-addressable storage and distributed architecture to establish a self-contained, auditable registry. The paper concludes with a complete implementation of the artifact signing script and practical recommendations for deployment.
+
+---
+
+### Introduction
+The ability to prove control of a cryptographic private key is fundamental to modern security protocols. Traditionally, centralized systems such as databases or timestamp authorities are used to provide uniqueness and replay resistance for signed proofs. However, these systems introduce dependencies and scalability challenges. This paper proposes a decentralized alternative that utilizes Git’s version control system as a global, immutable registry for cryptographic artifacts.
+
+The proposed method employs GPG (GNU Privacy Guard) for signing artifacts in a clearsigned format, embedding the artifact payload, signature, and public key fingerprint in a single self-contained document. Replay resistance and auditing are achieved through Git’s deduplication and content-addressable storage.
+
+---
+
+### Artifact Structure
+Artifacts are defined as self-contained, uniquely identifiable units that provide cryptographic proof of key ownership. The structure of an artifact is:
+
+```
+urn:artifact:<scope>:<random_sequence>
+```
+
+- **`<scope>`**: A static identifier defining the artifact’s context (e.g., `mattborja/identity`).
+- **`<random_sequence>`**: A 32-byte cryptographically secure random sequence ensuring uniqueness.
+
+An example artifact might look like:
+```
+urn:artifact:mattborja/identity:4BED165C91073D9F65B88DAC23AF5BCDE520F723C1E62A69B369F278
+```
+
+---
+
+### System Workflow
+
+#### Artifact Creation
+1. **Generate the Artifact**:
+   - Construct the artifact using the predefined format, ensuring that `<random_sequence>` is generated using a cryptographically secure random number generator (e.g., `openssl rand -hex 32`).
+
+2. **Clearsign the Artifact**:
+   - Use GPG to create a clearsigned artifact, which packages the artifact, signature, and public key fingerprint.
+
+#### Submission to Git
+1. **Add to Git**:
+   - Submit the clearsigned artifact to the parent project’s Git repository. Each artifact is stored as a uniquely named file (e.g., `artifact_<random_sequence>.asc`).
+
+2. **Commit and Push**:
+   - Use Git’s version control capabilities to commit the artifact and push it to the shared repository.
+
+#### Validation
+1. **Verify Signature**:
+   - Verifiers fetch the repository and validate the signature of the artifact using the corresponding public key.
+
+2. **Replay Resistance**:
+   - Git inherently prevents duplicate artifacts due to its hash-based storage. Replayed artifacts are rejected during the commit process.
+
+---
+
+### Advantages
+1. **Decentralized Replay Resistance**:
+   - Git’s content-addressable storage ensures that duplicate artifacts are automatically rejected.
+
+2. **Transparency and Auditing**:
+   - The repository acts as a public, immutable log of all submitted artifacts.
+
+3. **Self-Contained Proof**:
+   - Clearsigned artifacts include all necessary metadata for independent verification, eliminating external dependencies.
+
+4. **Collaborative Workflow**:
+   - Git’s distributed architecture enables seamless collaboration between signers and verifiers.
+
+---
+
+### Implementation
+
+#### Artifact Signing Script
+The following Bash script automates artifact creation and signing:
+
+```bash
+#!/bin/bash
+# MIT License
+# 
+# Copyright (c) 2025 Matt Borja
+# 
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+# 
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+# 
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+# Static scope parameter
+SCOPE="mattborja/identity"
+LOCAL_USER=""
+
+# Parse optional arguments
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --local-user)
+      LOCAL_USER="$2"
+      shift 2
+      ;;
+    *)
+      echo "Usage: $0 [--local-user <key_id>]"
+      exit 1
+      ;;
+  esac
+done
+
+# Generate a 32-byte cryptographically strong random sequence
+RANDOM_SEQUENCE=$(openssl rand -hex 32)
+
+# Construct the artifact
+ARTIFACT="urn:artifact:${SCOPE}:${RANDOM_SEQUENCE}"
+
+# Sign and output
+if [ -n "$LOCAL_USER" ]; then
+  echo "$ARTIFACT" | gpg --clearsign --local-user "$LOCAL_USER"
+else
+  echo "$ARTIFACT" | gpg --clearsign
+fi
+```
+
+---
+
+### Conclusion
+This approach leverages Git’s distributed, version-controlled architecture and GPG’s cryptographic guarantees to create a decentralized and transparent registry for cryptographic proofs. By eliminating dependencies on centralized authorities, it ensures replay resistance, traceability, and self-contained validation for modern cryptographic systems.
+
+Future work could explore automating this workflow further with CI/CD pipelines or integrating blockchain technologies for additional decentralization.

--- a/papers/self-attestation-gpg-keys-github-mattborja-2025.md
+++ b/papers/self-attestation-gpg-keys-github-mattborja-2025.md
@@ -1,0 +1,185 @@
+**Title:**
+Self-Attestation of Additional GPG Keys Using GitHub’s Internal Signing Key
+
+**Author:**
+Matt Borja
+
+**Copyright:**
+Copyright © 2025 Matt Borja\
+Licensed under the MIT License.
+
+---
+
+**Abstract**
+This document outlines a method for asserting ownership of an external GPG key in a GitHub repository with Vigilant Mode enabled. Since the GitHub-provided signing key used for commits cannot be exported, this process leverages a self-attestation statement to cryptographically link the external GPG key to the repository. The commit signature, clearsigned artifact, and self-attestation statement together establish decentralized proof of ownership. This approach ensures transparency, traceability, and compliance with GitHub’s security requirements.
+
+---
+
+### Introduction
+
+GitHub’s Vigilant Mode requires all commits to be signed with a GitHub-provided GPG key. While this key is suitable for ensuring commit authenticity, its non-exportable nature limits its use for external attestations. This document proposes a process that enables repository owners to claim ownership of an additional GPG key using a self-attestation statement. The self-attestation is made verifiable through the commit signature generated with GitHub’s internal GPG key, allowing decentralized and transparent proof of key ownership.
+
+---
+
+### Self-Attestation Process
+
+#### Prerequisite
+
+Refer to the "Open Proof of Cryptographic Key Ownership Using Git as a Registry" paper (Matt Borja, 2025) for the detailed steps required to generate and clearsign a unique artifact using the external GPG key. The artifact must follow the format defined in that paper (e.g., `urn:artifact:<scope>:<random_sequence>`). This clearsigned artifact will serve as cryptographic proof of ownership for the external GPG key and is a critical component of the self-attestation process.
+
+#### Formation of Self-Attestation Statement
+
+1. **Confirm Key ID**:
+
+   - Before proceeding, confirm the external GPG key ID to be used in the self-attestation.
+
+2. **Create the Self-Attestation Statement**:
+
+   - Declare ownership of the external GPG key.
+   - Include the fingerprint of the external GPG key and reference the clearsigned artifact, as outlined in the "Open Proof of Cryptographic Key Ownership Using Git as a Registry" paper (Matt Borja, 2025). Ensure the artifact follows the required format and is clearsigned using the external GPG key.
+   - Example statement:
+     ```
+     # Self-Attestation Statement
+     
+     I, [GitHub Username], hereby claim ownership of the GPG key with fingerprint:
+     <public_key_fingerprint>
+
+     Artifact signed with this key:
+     -----BEGIN PGP SIGNED MESSAGE-----
+     Hash: SHA256
+
+     urn:artifact:<scope>:<random_sequence>
+     -----BEGIN PGP SIGNATURE-----
+
+     ...
+     -----END PGP SIGNATURE-----
+     ```
+
+3. **Save the Statement**:
+
+   - Save the self-attestation statement to a file named `repo-attest-KEYID.txt` to align the filename with the external key ID being attested.
+
+#### Commit the Self-Attestation
+
+1. **Add the Self-Attestation Using GitHub’s Web Interface**:
+
+   - **Recommended.** Ensure you have [Vigilant Mode](https://docs.github.com/github/authenticating-to-github/displaying-verification-statuses-for-all-of-your-commits) enabled for your GitHub account.
+   - Navigate to the target repository on GitHub.
+   - Use only the GitHub web interface to upload the `repo-attest-KEYID.txt` file containing your self-attestation statement.
+
+2. **Create a Signed Commit**:
+
+   - During the file upload process, enter a descriptive commit message, such as:
+     ```
+     Self-attestation of external GPG key ownership
+     ```
+   - Complete the commit process. GitHub’s internal signing key will automatically sign the commit under Vigilant Mode.
+
+By using GitHub's internal non-exportable GPG key, this method ensures the authenticity of the commit while maintaining compatibility with Vigilant Mode's strict security requirements.
+
+---
+
+### Validation of Self-Attestation
+
+#### Practical Example
+Suppose a user with GitHub username `mattborja` wants to self-attest ownership of the GPG key with fingerprint `99BB608E30380C451952D6BBA1C7E813F160A407` (in accordance with the aforementioned artifact requirements).
+
+1. **Generate and Clearsign the Artifact**:
+   ```bash
+   sh ./artifact-sign.sh --local-user 99BB608E30380C451952D6BBA1C7E813F160A407
+   ```
+
+2. **Create the Self-Attestation Statement**:
+   Build a self-attestation statement with the resulting clearsigned artifact appended as follows. Replace `<scope>` and `<random_sequence>` with the actual values used in your artifact:
+   ```
+   # Self-Attestation Statement
+   
+   I, @mattborja, hereby claim ownership of the GPG key with fingerprint:
+   99BB608E30380C451952D6BBA1C7E813F160A407
+
+   Artifact signed with this key:
+   -----BEGIN PGP SIGNED MESSAGE-----
+   Hash: SHA512
+
+   urn:artifact:mattborja/identity:ad7b6bf381cdffe7b025e9943d46c2eae7d0e5bb483a93867be4ed060aa33fe3
+   -----BEGIN PGP SIGNATURE-----
+
+   iHUEARYKAB0WIQTUGoPhxrcBYZ0NgS/D9p0b5ry9FgUCZ3Bp9wAKCRDD9p0b5ry9
+   FiDsAPsH2NXrLLlIE0pFe27v04/B/yi4xbq+gu7uWlwC/huz3gEA0L2WDxqGj+fP
+   O6PQJZHqNEXo68fFMlP/JYErl8vxFwY=
+   =UBtD
+   -----END PGP SIGNATURE-----
+   ```
+
+3. **Upload and Commit the File**:
+   - Use GitHub’s web interface to create this file as `repo-attest-99BB608E30380C451952D6BBA1C7E813F160A407.txt`.
+   - Add an appropriate commit message: `Self-attestation of external GPG key: 99BB608E30380C451952D6BBA1C7E813F160A407`.
+
+This example completes the process from start to finish.
+
+### Validation of Self-Attestation
+
+1. **Verify the Commit Signature**:
+
+   - Ensure the commit containing the self-attestation is signed with GitHub’s internal GPG key:
+     ```bash
+     git log --show-signature
+     ```
+   - Confirm that the signature matches GitHub’s key.
+
+2. **Validate the Artifact Signature**:
+
+   - Extract and validate the artifact within the self-attestation statement using the claimed external GPG key:
+     ```bash
+     gpg --verify <clearsigned_artifact_section>
+     ```
+
+3. **Check Consistency**:
+
+   - Ensure the external GPG key’s fingerprint in the self-attestation matches the fingerprint of the key used to sign the artifact.
+   - Confirm the artifact is cryptographically valid.
+
+---
+
+### Advantages
+
+#### Clarification on External Key Signing
+
+If the GitHub-provided internal GPG key were exportable, the external GPG key could simply be signed directly by the GitHub key, providing a streamlined method to establish ownership. However, since the internal key is non-exportable, this process relies on a self-attestation statement and commit signature to establish a verifiable chain of ownership.
+
+1. **Commit Signature Validity**:
+
+   - The GitHub-signed commit provides strong evidence that the self-attestation originates from the repository owner.
+
+2. **Cryptographic Proof**:
+
+   - The external GPG key’s ownership is demonstrated through the clearsigned artifact.
+
+3. **Immutability and Transparency**:
+
+   - Once committed, the self-attestation and associated files are part of the immutable repository history, ensuring transparency.
+
+4. **Alignment with GitHub’s Vigilant Mode**:
+
+   - The process complies with Vigilant Mode’s requirement for commits to be signed with GitHub’s internal GPG key.
+
+---
+
+### Recommendations
+
+1. **Standardized Self-Attestation Format**:
+
+   - Adopt a standardized template for self-attestation statements to reduce ambiguity and improve verifiability.
+
+2. **Automate Validation**:
+
+   - Develop scripts or CI workflows to automate the validation of commit signatures, self-attestation statements, and artifact signatures.
+
+3. **Publish External GPG Key**:
+
+   - Ensure the public key of the external GPG key is available on trusted keyservers for independent verification.
+
+---
+
+This approach enables users to assert ownership of additional GPG keys while maintaining compliance with GitHub’s Vigilant Mode. By leveraging cryptographic proofs and Git’s immutable history, it provides a transparent and decentralized mechanism for establishing key ownership.
+

--- a/registry/repo-attest-99BB608E30380C451952D6BBA1C7E813F160A407.txt
+++ b/registry/repo-attest-99BB608E30380C451952D6BBA1C7E813F160A407.txt
@@ -1,0 +1,17 @@
+# Self-Attestation Statement
+
+I, @mattborja, hereby claim ownership of the GPG key with fingerprint:
+99BB608E30380C451952D6BBA1C7E813F160A407
+
+Artifact signed with this key:
+-----BEGIN PGP SIGNED MESSAGE-----
+Hash: SHA512
+
+urn:artifact:mattborja/identity:ad7b6bf381cdffe7b025e9943d46c2eae7d0e5bb483a93867be4ed060aa33fe3
+-----BEGIN PGP SIGNATURE-----
+
+iHUEARYKAB0WIQTUGoPhxrcBYZ0NgS/D9p0b5ry9FgUCZ3Bp9wAKCRDD9p0b5ry9
+FiDsAPsH2NXrLLlIE0pFe27v04/B/yi4xbq+gu7uWlwC/huz3gEA0L2WDxqGj+fP
+O6PQJZHqNEXo68fFMlP/JYErl8vxFwY=
+=UBtD
+-----END PGP SIGNATURE-----


### PR DESCRIPTION
Papers included in this changeset:
- Open Proof of Cryptographic Key Ownership Using Git as a Registry
- Self-Attestation of Additional GPG Keys Using GitHub’s Internal Signing Key

Verifiable ID proofs may include (but are not limited to):
- Public key cryptography components
- Licenses, fingerprints, certifications, etc.
- Project involvement, published content, user activity, etc.
- Secure telecommunication