### PR TITLE
Readme: Separate filename indication from JSON in instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,13 +69,14 @@ The `tags` property is an array of strings representing categories or roles asso
 ["OWASP", "Software Developer"]
 ```
 
-### Complete Example
+### JSON Example
 
-Below is a fully populated, schema-compliant JSON example:
+Below is a theoretical example that would be proposed via new Pull Request as follows:
+
+Filename: **/registry/259A55407DD6C00299E6607EFFDE55BE73A2D1ED.json**
 
 ```json
 {
-  "filename": "259A55407DD6C00299E6607EFFDE55BE73A2D1ED.json",
   "fingerprint": "259A55407DD6C00299E6607EFFDE55BE73A2D1ED",
   "label": "Jeremy Long",
   "validity": "full",

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The `refs` property contains an array of reference objects that support the iden
 | `url`      | A link to an authoritative source validating the reference.          | `https://github.com/OWASP/www-project-dependency-check`   |
 | `type`     | The type of evidence provided. Possible values: `role`, `user`, `key`.| `role`                                                   |
 
-**Full Example of `refs` Collection:**
+**Full Example of `refs` Collection**
 ```json
 [
   {


### PR DESCRIPTION
Cleans up erroneous `filenmae` key in JSON example