### PR TITLE
Feature: Add proofs from LinkedIn for own key (A1C7 E813 F160 A407)

### DIFF
--- a/registry/99BB608E30380C451952D6BBA1C7E813F160A407.json
+++ b/registry/99BB608E30380C451952D6BBA1C7E813F160A407.json
@@ -13,6 +13,18 @@
       "date": "2024-10-06",
       "comment": "Cross-signed by F30FF4FC936584574EE3251833688C2EDC08CD38",
       "type": "user"
+    },
+    {
+      "date": "2025-01-17",
+      "comment": "Listed on LinkedIn profile as Download Public PGP Key link",
+      "type": "user",
+      "url": "https://www.linkedin.com/in/mattborja"
+    },
+    {
+      "date": "2025-01-17",
+      "comment": "LinkedIn profile showing identity verification by CLEAR using government ID",
+      "type": "user",
+      "url": "https://www.linkedin.com/help/linkedin/answer/a1359065"
     }
   ],
   "tags": [


### PR DESCRIPTION
LinkedIn partners with CLEAR to conduct various forms of identity verification and feature a verification badge on one's LinkedIn profile as a means of tokenizing or otherwise abstracting away the identity verification process without the need to continue sharing government IDs, etc.