### PR TITLE
CI: Add default pull request template for submitting key proofs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/keyproofs.md
+++ b/.github/PULL_REQUEST_TEMPLATE/keyproofs.md
@@ -1,0 +1,21 @@
+Key ID (First Name, Last Name):  
+&gt; 
+
+Full length GPG fingerprint:  
+&gt;
+
+Proposed key validity ([learn more](https://www.gnupg.org/gph/en/manual/x334.html)):  
+&gt; `marginal`
+
+Public key sources (URLs only):  
+&gt; https://github.com/username.gpg (preferred)  
+&gt; 
+
+Proofs:  
+&gt; One-line summary of key proof 1  
+&gt; One-line summary of key proof 2  
+&gt; One-line summary of key proof 3  
+&gt; ...
+
+---
+**Tip:** Type a `space` *twice* at the end of a line to cause Markdown to wrap the text that follows onto the next line.


### PR DESCRIPTION
## Template
Key ID (First Name, Last Name):  
&gt; 

Full length GPG fingerprint:  
&gt;

Proposed key validity ([learn more](https://www.gnupg.org/gph/en/manual/x334.html)):  
&gt; `marginal`

Public key sources (URLs only):  
&gt; https://github.com/username.gpg (preferred)  
&gt; 

Proofs:  
&gt; One-line summary of key proof 1  
&gt; One-line summary of key proof 2  
&gt; One-line summary of key proof 3  
&gt; ...

---
**Tip:** Type a `space` *twice* at the end of a line to cause Markdown to wrap the text that follows onto the next line.

## Recommended Usage
With [query parameters](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/using-query-parameters-to-create-a-pull-request):

- `&title=Key%20proofs%20for%20%40username%20(0000%200000%200000%200000)`
- `&labels=valid+key+proofs+needed`
- `&template=keyproofs.md`
